### PR TITLE
Add OpenSearch support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,6 +31,7 @@
   <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/manifest.json">
+  <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Fisherman">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,13 @@ title: Fisherman
 </section>
 
 <section class="hero">
-    <div class="container" id="searchdiv"></div>
+    <div class="container" id="searchdiv">
+      <form>
+        <input id="search" type="search" name="q"
+         class="form-control" aria-label="Search Fisherman Plugins">
+        <div id="results"></div>
+      </form>
+    </div>
 </section>
 
 <section class="github-share hidden-lg hidden-md hidden-sm">

--- a/js/search.js
+++ b/js/search.js
@@ -87,29 +87,49 @@ var setVal = function(item) {
   })
 }
 
+var searchQueryString = function() {
+
+  var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1)
+
+  var retval = ''
+
+  $.each(hashes.split('&'), function(i, query) {
+
+    kv = query.split('=')
+
+    if (kv[0] == 'q') {
+      console.log('returning ' + kv[1]);
+      retval = kv[1]
+    }
+
+  })
+
+  return retval
+
+}
+
 $.get(source, function(data) {
   var plugs = data.split("\n\n")
 
     for (var i=0; i<plugs.length; i++) {
       var dat = plugs[i].split("\n")
 
-        plugins.push({
-          "title" : dat[0],
-          "url": dat[1],
-          "desc": dat[2],
-          "tagstring": dat[3],
-          "tags": dat[3].trim().split(" "),
-          "author": dat[4]
-        })
+      plugins.push({
+        "title" : dat[0],
+        "url": dat[1],
+        "desc": dat[2],
+        "tagstring": dat[3],
+        "tags": dat[3].trim().split(" "),
+        "author": dat[4]
+      })
     }
 
   fusePlugins = new Fuse(plugins, options)
 
-    $("#searchdiv")
-        .html("<input type=\"search\" name=\"search\" class=\"form-control\" id=\"search\" placeholder=\"Search "
-            + plugins.length + " Plugins...\"/><div id=\"results\"></div>")
+  $("#search").attr('placeholder', "Search " + plugins.length + " Plugins...")
 
-    $("#search").on("input", function(){
-      runSearch(fusePlugins)
-    })
+  $("#search").on("input", function() {
+    runSearch(fusePlugins)
+  }).val(searchQueryString()).trigger('input')
+
 })

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Fisherman</ShortName>
+  <Description>Search Fisherman Plugins</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">http://fisherman.sh/favicon.ico</Image>
+  <Url type="text/html" method="get" template="http://fisherman.sh?q={searchTerms}"/>
+  <moz:SearchForm>http://fisherman.sh</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Uses a query string to provide support for OpenSearch plugins across various browsers.  Tested on Chrome, Vivaldi and Firefox.