### PR TITLE
Update jQuery URL to use protocol-relative URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/css/style.css"/>
   <link rel="stylesheet" href ="/css/asciinema-player.css"/>
-  <script src="http://code.jquery.com/jquery-1.12.0.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.12.0.min.js"></script>
   <script src="/js/fuse.min.js"></script>
   <script src="/js/asciinema-player.js"></script>
 


### PR DESCRIPTION
This should make the search usable on `https` (unless there are other, further errors).