### PR TITLE
Update FAQ url in the footer to a working one

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
             <ul>
                 <li><a href="https://github.com/fisherman">GitHub</a></li>
                 <li><a href="https://github.com/fisherman/fisherman/releases">Releases</a></li>
-                <li><a href="https://github.com/fisherman/fisherman/wiki/FAQ">FAQ</a></li>
+                <li><a href="https://github.com/fisherman/fisherman#faq">FAQ</a></li>
                 <li><a href="https://github.com/fisherman"><i class="fa fa-anchor"></i></a></li>
             </ul>
         </div>


### PR DESCRIPTION
Replaces the current FAQ url in the footer (https://github.com/fisherman/fisherman/wiki/FAQ), that points to a non-existent wiki page, with the FAQ url from the header (https://github.com/fisherman/fisherman#faq).